### PR TITLE
docs: Iteration 2 close-out — README architecture section and sprint cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ todo-app/
 ```
 
 
+## Architecture & Data Flow
+- Browser → React (port 3000) → fetch → FastAPI (port 8000) → SQLAlchemy → Postgres (port 5432)
+- Startup order (Docker): Postgres → API (waits for DB healthy) → Frontend (waits for API healthy)
+- CORS: Only http://localhost:3000 is allowed as a cross-origin caller
+- All API calls flow through useApi.js → makeAPICall(), which enforces an origin-pinned URL check before every fetch()
+
+
 ## Getting Started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -125,11 +125,16 @@ cd todo-app
 ```
 
 ### Running the App
-Run the CLI (backend):
+First have docker running with `docker compose up --build --wait` to ensure the database, api & frontend are ready.
+Then run the CLI with the following command.
+
+Run the CLI with docker (backend):
 ```sh
-python backend/commandline_interface/main.py
+docker compose exec -w /app api /opt/venv/bin/python -m commandline_interface.main
 ```
 
+Local development without Docker:
+```sh
 Run the frontend (development):
 ```sh
 cd frontend
@@ -137,9 +142,14 @@ npm install
 npm run dev
 ```
 
-Or run the full stack with Docker Compose (if configured):
+Run the full stack with Docker Compose:
 ```sh
 docker compose up --build --wait
+```
+
+Stopping the app:
+```sh
+docker compose down
 ```
 
 - Full reset if local state gets stuck (destructive): `docker compose down -v && docker compose up -d --build --wait`
@@ -216,10 +226,10 @@ docker run --rm todo-app-frontend-test npm run test -- --run src/test/unit
    - Or close the frontend browser tab.
 
 
-### Example Workflow
+### Example Workflow in CLI
 1. Start the CLI:
    ```sh
-   python backend/commandline_interface/main.py
+   docker compose exec -w /app api /opt/venv/bin/python -m commandline_interface.main
    ```
 2. Add a folder:
    - Choose `folders` → `add` in the CLI
@@ -234,8 +244,9 @@ docker run --rm todo-app-frontend-test npm run test -- --run src/test/unit
 
 5. Exit the CLI:
    - Enter `exit`
-   - Or stop `docker compose` / close the frontend tab.
 
+6. Exit Docker Compose:
+   - Stop with `docker compose down`
 
 ---
 

--- a/backend/commandline_interface/main.py
+++ b/backend/commandline_interface/main.py
@@ -4,6 +4,8 @@ from library.folder import Folder
 from library.folder_manager import FolderManager
 
 
+# This file contains the main command line interface for the Todo List App.
+# It allows users to manage folders and items through a series of prompts and commands.
 def todo_list():
     folder_manager = FolderManager()
     effect_bold(f"{Color.MAGENTA}Welcome to the Todo List App!{Color.OFF}")  # Initialize an empty todo list

--- a/backend/library/folder_manager.py
+++ b/backend/library/folder_manager.py
@@ -3,6 +3,8 @@ from typing import Dict, List, Union
 from library.folder import Folder
 
 
+# This class is responsible for managing folders within the CLI app.
+# It provides functions to add, edit, remove, and search for folders.
 class FolderManagerConstants:
     ERR_ADD_FOLDER_NON_STR = "input is not a string"
     ERR_EMPTY_FOLDER = "input is empty"


### PR DESCRIPTION
## Summary
- Adds Architecture & Data Flow section to README (browser→React→FastAPI→Postgres pipeline, Docker startup order, CORS, origin-pinned URL)
- Trailing whitespace cleanup in useApi.js
- Sprint close branch for Iter 2 close-out documentation

## Context
Final cleanup from Iteration 2 close-out. All sprint work was delivered via PR #77 (TD-005, TD-013) and PR #92 (TD-018). This PR captures remaining documentation improvements made during the close-out process.