### PR TITLE
ci(dependabot): scope frontend npm groups to minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,16 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 3
     groups:
-      react-stack:
+      react-stack-minor:
         patterns:
           - "react"
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
-      test-and-lint:
+        update-types:
+          - "minor"
+          - "patch"
+      test-and-lint-minor:
         patterns:
           - "vitest*"
           - "@testing-library/*"
@@ -39,6 +42,9 @@ updates:
           - "prettier"
           - "@vitejs/*"
           - "vite"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/backend"


### PR DESCRIPTION
## Summary

Narrows the two frontend npm Dependabot groups to **minor and patch** updates only, so that major version bumps arrive as standalone PRs and can be evaluated independently. Renames the groups to make the scoping explicit.

- `react-stack` → `react-stack-minor` (adds `update-types: [minor, patch]`)
- `test-and-lint` → `test-and-lint-minor` (adds `update-types: [minor, patch]`)

## Why

Grouped Dependabot PRs currently bundle major version bumps together with unrelated patch updates. When a single major bump in the group requires manual review or has breaking changes, the entire group PR becomes unmergeable — blocking otherwise-safe patch updates from landing.

By constraining the groups to `minor` + `patch`, Dependabot will:
- Continue bundling routine patch/minor updates into a single reviewable PR
- Automatically split **major** version bumps into their own standalone PRs, outside the group, where they can be reviewed and merged on their own merits

## Unblocks

- Closes #118 — the eslint 9→10 major bump is currently bundled inside `test-and-lint` alongside patch updates and is unmergeable as-is. After this change lands and Dependabot re-runs, eslint 9→10 will recreate as a standalone PR and the remaining patch updates will form a clean grouped PR.

## ⚠️ Operational note

The group renames (`react-stack` → `react-stack-minor`, `test-and-lint` → `test-and-lint-minor`) will cause Dependabot to **close any in-flight grouped PRs** under the old group names on its next run. Those updates will be **recreated** under the new group names (or split out as standalone majors). No action required — this is expected behavior.

## Scope

- Single file changed: `.github/dependabot.yml` (+8 / -2)
- No code, test, or runtime behavior changes
- No CI workflow edits

## Review

Reviewed by qa-architect — **APPROVE-WITH-EDITS** (conditions met).
QA review session: `ses_1f125c615ffeXkF1FwKrtvCK8B`

## Test plan

CI-only change. Verification will occur on the next scheduled Dependabot run (or manual trigger via repo Insights → Dependency graph → Dependabot).
Expected outcome:
- Existing `react-stack` / `test-and-lint` PRs (if any) close automatically
- New `react-stack-minor` / `test-and-lint-minor` grouped PRs open
- eslint 9→10 (and any other pending majors) appear as standalone PRs