### PR TITLE
fix(security): upgrade urllib3 to 2.7.0 and add backend .dockerignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,19 @@
+# Dev environment — never copy into Docker image
+.venv/
+
+# Python cache artefacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage / test outputs
+.coverage
+coverage.xml
+htmlcov/
+
+# Local tooling
+runtime-requirements.txt

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1219,11 +1219,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity CVEs surfaced by the nightly backend job (#87 run 25846888574).

### Root causes

| Job | Failing step | Cause |
|---|---|---|
| Backend quality + audit | `pip-audit` | `urllib3 2.6.3` — CVE-2026-44431 and CVE-2026-44432 |
| Docker build + Trivy | Trivy scan | No `backend/.dockerignore` → `COPY . .` baked local `.venv` (urllib3 2.6.3) into image |

### Changes
- `backend/uv.lock` — urllib3 2.6.3 → 2.7.0 via `uv lock --upgrade-package urllib3`
- `backend/.dockerignore` — new file; excludes `.venv`, `__pycache__`, caches, coverage artefacts from Docker build context

### Verification (local Docker)
- `pip-audit`: No known vulnerabilities found
- Trivy: 0 HIGH/CRITICAL findings (urllib3 2.7.0 · 0 vulns)