### PR TITLE
fix(security): pin starlette>=1.0.1 to resolve PYSEC-2026-161

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "fastapi>=0.118.0",
 
     # Explicit overrides to avoid known vulnerable transitive versions
-    "starlette>=1.0.0",
+    "starlette>=1.0.1",
     "python-multipart>=0.0.27",
     "urllib3>=2.6.3",
     "idna>=3.15",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -74,7 +74,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
-    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", specifier = ">=0.46.0" },
 ]
@@ -1175,15 +1175,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hotfix for the nightly backend CI failure. `pip-audit` flagged `starlette==1.0.0` with **PYSEC-2026-161** (fix version: 1.0.1).

## Changes
- Bumped `starlette>=1.0.1` in `backend/pyproject.toml`
- Updated `backend/uv.lock`: `starlette 1.0.0 → 1.2.0`

## Verification
Docker-first: `pip-audit` inside the backend test image returns **No known vulnerabilities found** ✓